### PR TITLE
기념일 관리 기능 구현 및 테스트 코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ repositories {
 }
 
 dependencies {
+    testImplementation 'org.mockito:mockito-inline:4.0.0'
+
     // GraphQL
     implementation 'org.springframework.boot:spring-boot-starter-graphql'
 

--- a/src/main/java/bit/anniversary/controller/AnController.java
+++ b/src/main/java/bit/anniversary/controller/AnController.java
@@ -12,9 +12,11 @@ import bit.anniversary.dto.AnReqDto;
 import bit.anniversary.dto.AnResDto;
 import bit.anniversary.service.AnService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 
 @Controller
 @RequiredArgsConstructor
+@Log4j2
 public class AnController {
 
 	private final AnService anniversaryService;
@@ -22,6 +24,7 @@ public class AnController {
 	// 기념일 생성
 	@MutationMapping
 	public AnResDto createAnniversary(@Argument("anDto") AnReqDto anReqDto) {
+		log.info("anReqDto ==> {}",anReqDto);
 		return anniversaryService.createAnniversary(anReqDto);
 	}
 

--- a/src/main/java/bit/anniversary/controller/AnController.java
+++ b/src/main/java/bit/anniversary/controller/AnController.java
@@ -1,63 +1,64 @@
 package bit.anniversary.controller;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
-import org.modelmapper.ModelMapper;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
 
-import bit.anniversary.dto.AnDto;
+import bit.anniversary.dto.AnReqDto;
 import bit.anniversary.dto.AnResDto;
-import bit.anniversary.sevice.AnService;
+import bit.anniversary.service.AnService;
 import lombok.RequiredArgsConstructor;
 
 @Controller
 @RequiredArgsConstructor
 public class AnController {
 
-	private final AnService anniversaryservice;
+	private final AnService anniversaryService;
 
-	private final ModelMapper modelMapper;
-	// 	TODO: 기념일 설정 기능
-	// 	TODO: 함께 하는 사람 , 글쓴이 회원가입 이후 구현.
+	// 기념일 생성
 	@MutationMapping
-	public AnResDto createAnniversary(@Argument("anDto") AnDto anDto) {
-		System.out.println("Received anDto: " + anDto);
-		if (anDto == null) {
-			throw new IllegalArgumentException("anDto cannot be null");
-		}
-		return anniversaryservice.saveAnniverSary(anDto).createAnReqDto(modelMapper);
+	public AnResDto createAnniversary(@Argument("anDto") AnReqDto anReqDto) {
+		return anniversaryService.createAnniversary(anReqDto);
 	}
 
-	//	TODO: 기념일 업데이트 기능
-	// 	Input : 기념일 시간 , 입력 시간 , 수정 시간 , 기념일 제목 ,글쓴이 , 함께 하는 사람 ,기념일 내용
-	// 	TODO: 함께 하는 사람 , 글쓴이 회원가입 이후 구현
+	// 기념일 업데이트
 	@MutationMapping
-	public AnResDto updateAnniversary(@Argument AnDto andto) {
-		return anniversaryservice.updateAnniverSary(andto).createAnReqDto(modelMapper);
+	public AnResDto updateAnniversary(@Argument("id") Long id, @Argument("anDto") AnReqDto anReqDto) {
+		return anniversaryService.updateAnniversary(id, anReqDto);
 	}
 
-	//	TODO: 기념일 삭제 기능
-	//  Input : 기념일 id
-	//  TODO:
+	// 기념일 삭제
 	@MutationMapping
-	public AnResDto deleteAnniversary(@Argument AnDto andto) {
-		anniversaryservice.deleteAnniverSary(andto);
-		return andto.createAnReqDto(modelMapper);
+	public Boolean deleteAnniversary(@Argument("id") Long id) {
+		anniversaryService.deleteAnniversary(id);
+		return true;
 	}
 
-	//  TODO: 기념일 가져오는기능
+	// 특정 기념일 조회
 	@QueryMapping
-	public AnResDto getAnniversary(@Argument AnDto andto) {
-		return anniversaryservice.getAnniverSary(andto);
+	public AnResDto getAnniversary(@Argument Long id) {
+		return anniversaryService.getAnniversary(id);
 	}
 
-	// TODO : 기념일 리스트 가져오는기능
+	// 날짜 범위로 기념일 목록 조회
 	@QueryMapping
-	public List<AnResDto> getListAnniversary() {
-		return anniversaryservice.getAnniverSaryList();
+	public List<AnResDto> getAnniversariesInRange(@Argument LocalDateTime startDate, @Argument LocalDateTime endDate) {
+		return anniversaryService.findAnniversariesInRange(startDate, endDate);
 	}
 
+	// 한 달 기념일 목록 조회
+	@QueryMapping
+	public List<AnResDto> getMonthlyAnniversaries() {
+		return anniversaryService.findAnniversariesInRange(LocalDateTime.now(), LocalDateTime.now().plusMonths(1));
+	}
+
+	// 1년 기념일 목록 조회
+	@QueryMapping
+	public List<AnResDto> getYearlyAnniversaries() {
+		return anniversaryService.findAnniversariesInRange(LocalDateTime.now(), LocalDateTime.now().plusYears(1));
+	}
 }

--- a/src/main/java/bit/anniversary/dto/AnDto.java
+++ b/src/main/java/bit/anniversary/dto/AnDto.java
@@ -2,11 +2,8 @@ package bit.anniversary.dto;
 
 import lombok.*;
 import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import bit.anniversary.entity.Anniversary;
-
 import java.time.LocalDateTime;
 
 @Getter
@@ -14,30 +11,18 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Setter // TODO : 현재 파악한 소스로 graphql 에는 Setter 을 사용해야 된다.-> 추후 이유 찾아봄
+@Setter
 public class AnDto {
 
-    private Long id;
-    private String writeTime;
-    private String title;
-    private String writer;
-    private String withPeople;
-    private String updateTime;
-    private String content;
-    private LocalDateTime anniversaryDate;
+	private Long id;
+	private String writeTime;
+	private String title;
+	private String updateTime;
+	private String content;
+	private LocalDateTime anniversaryDate;
 
-    // NOTE: DTO에서 Entity로 변환하는 메서드
-    public Anniversary creatAnniversary(ModelMapper modelMapper) {
-        return modelMapper.map(this, Anniversary.class);
-    }
-
-    // NOTE: DTO에서 Response DTO로 변환하는 메서드
-    public AnResDto createAnReqDto(ModelMapper modelMapper) {
-        return modelMapper.map(this, AnResDto.class);
-    }
-
-    // NOTE: Entity에서 DTO로 변환하는 메서드 (정적 메서드로 정의)
-    public static AnDto of(Anniversary anniversary, ModelMapper modelMapper) {
-        return modelMapper.map(anniversary, AnDto.class);
-    }
+	// DTO에서 Entity로 변환하는 메서드
+	public Anniversary createAnniversary(ModelMapper modelMapper) {
+		return modelMapper.map(this, Anniversary.class);
+	}
 }

--- a/src/main/java/bit/anniversary/dto/AnDto.java
+++ b/src/main/java/bit/anniversary/dto/AnDto.java
@@ -1,28 +1,30 @@
 package bit.anniversary.dto;
 
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
 import org.modelmapper.ModelMapper;
-
 import bit.anniversary.entity.Anniversary;
-import java.time.LocalDateTime;
+import lombok.Setter;
 
 @Getter
-@ToString
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Setter
+@Builder
 public class AnDto {
 
-	private Long id;
-	private String writeTime;
-	private String title;
-	private String updateTime;
-	private String content;
-	private LocalDateTime anniversaryDate;
+	private final Long id;
+	private final String writerEmail;
+	private final String withPeopleEmail;
+	private final String writeTime;
+	private final String title;
+	private final String updateTime;
+	private final String content;
+	private final String anniversaryDate;
 
-	// DTO에서 Entity로 변환하는 메서드
-	public Anniversary createAnniversary(ModelMapper modelMapper) {
+	public Anniversary toEntity(ModelMapper modelMapper) {
 		return modelMapper.map(this, Anniversary.class);
+	}
+
+	public static AnDto fromEntity(Anniversary anniversary, ModelMapper modelMapper) {
+		return modelMapper.map(anniversary, AnDto.class);
 	}
 }

--- a/src/main/java/bit/anniversary/dto/AnDto.java
+++ b/src/main/java/bit/anniversary/dto/AnDto.java
@@ -7,7 +7,6 @@ import bit.anniversary.entity.Anniversary;
 import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class AnDto {
 

--- a/src/main/java/bit/anniversary/dto/AnReqDto.java
+++ b/src/main/java/bit/anniversary/dto/AnReqDto.java
@@ -1,0 +1,17 @@
+package bit.anniversary.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AnReqDto {
+
+	private String writerEmail;
+	private String withPeopleEmail;
+	private String writeTime;
+	private String title;
+	private String updateTime;
+	private String content;
+	private String anniversaryDate;
+}

--- a/src/main/java/bit/anniversary/dto/AnReqDto.java
+++ b/src/main/java/bit/anniversary/dto/AnReqDto.java
@@ -3,9 +3,10 @@ package bit.anniversary.dto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
-@Setter
+@ToString
 public class AnReqDto {
 
 	private final String writerEmail;

--- a/src/main/java/bit/anniversary/dto/AnReqDto.java
+++ b/src/main/java/bit/anniversary/dto/AnReqDto.java
@@ -1,5 +1,6 @@
 package bit.anniversary.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,11 +8,34 @@ import lombok.Setter;
 @Setter
 public class AnReqDto {
 
-	private String writerEmail;
-	private String withPeopleEmail;
-	private String writeTime;
-	private String title;
-	private String updateTime;
-	private String content;
-	private String anniversaryDate;
+	private final String writerEmail;
+	private final String withPeopleEmail;
+	private final String writeTime;
+	private final String title;
+	private final String updateTime;
+	private final String content;
+	private final String anniversaryDate;
+
+	@Builder
+	public AnReqDto(String writerEmail, String withPeopleEmail, String writeTime, String title, String updateTime, String content, String anniversaryDate) {
+		this.writerEmail = writerEmail;
+		this.withPeopleEmail = withPeopleEmail;
+		this.writeTime = writeTime;
+		this.title = title;
+		this.updateTime = updateTime;
+		this.content = content;
+		this.anniversaryDate = anniversaryDate;
+	}
+
+	public AnDto toAnDto() {
+		return AnDto.builder()
+			.writerEmail(this.writerEmail)
+			.withPeopleEmail(this.withPeopleEmail)
+			.writeTime(this.writeTime)
+			.title(this.title)
+			.updateTime(this.updateTime)
+			.content(this.content)
+			.anniversaryDate(this.anniversaryDate)
+			.build();
+	}
 }

--- a/src/main/java/bit/anniversary/dto/AnResDto.java
+++ b/src/main/java/bit/anniversary/dto/AnResDto.java
@@ -1,13 +1,10 @@
 package bit.anniversary.dto;
 
 import java.time.LocalDateTime;
-
 import bit.user.dto.UserResponse;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class AnResDto {
 
 	private Long id;
@@ -27,7 +24,7 @@ public class AnResDto {
 		resDto.title = anDto.getTitle();
 		resDto.updateTime = anDto.getUpdateTime();
 		resDto.content = anDto.getContent();
-		resDto.anniversaryDate = anDto.getAnniversaryDate();
+		resDto.anniversaryDate = anDto.getAnniversaryDate() != null ? LocalDateTime.parse(anDto.getAnniversaryDate()) : null;
 		resDto.writer = writer;
 		resDto.withPeople = withPeople;
 		resDto.daysToAnniversary = daysToAnniversary;

--- a/src/main/java/bit/anniversary/dto/AnResDto.java
+++ b/src/main/java/bit/anniversary/dto/AnResDto.java
@@ -2,34 +2,35 @@ package bit.anniversary.dto;
 
 import java.time.LocalDateTime;
 
-import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
-import lombok.Builder;
+import bit.user.dto.UserResponse;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class AnResDto {
 
 	private Long id;
-
 	private String writeTime;
-
 	private String title;
-
-	private String writer;
-
-	private String withPeople;
-
 	private String updateTime;
-
 	private String content;
-
 	private LocalDateTime anniversaryDate;
+	private UserResponse writer;
+	private UserResponse withPeople;
+	private long daysToAnniversary;
 
-	public static AnResDto of(AnDto anDto,ModelMapper modelMapper) {
-		return modelMapper.map(anDto, AnResDto.class);
+	public static AnResDto from(AnDto anDto, UserResponse writer, UserResponse withPeople, long daysToAnniversary) {
+		AnResDto resDto = new AnResDto();
+		resDto.id = anDto.getId();
+		resDto.writeTime = anDto.getWriteTime();
+		resDto.title = anDto.getTitle();
+		resDto.updateTime = anDto.getUpdateTime();
+		resDto.content = anDto.getContent();
+		resDto.anniversaryDate = anDto.getAnniversaryDate();
+		resDto.writer = writer;
+		resDto.withPeople = withPeople;
+		resDto.daysToAnniversary = daysToAnniversary;
+		return resDto;
 	}
-
 }

--- a/src/main/java/bit/anniversary/entity/Anniversary.java
+++ b/src/main/java/bit/anniversary/entity/Anniversary.java
@@ -1,22 +1,13 @@
 package bit.anniversary.entity;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-
+import lombok.*;
 import org.modelmapper.ModelMapper;
-
 import bit.anniversary.dto.AnDto;
 import bit.user.entity.UserEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Entity
 @Getter
@@ -43,12 +34,10 @@ public class Anniversary {
 	@JoinColumn(name = "with_people_id")
 	private UserEntity withPeople;
 
-	// 기념일 DTO 생성 메서드
 	public AnDto toDto(ModelMapper modelMapper) {
 		return modelMapper.map(this, AnDto.class);
 	}
 
-	// 기념일 업데이트
 	public void updateAnniversary(AnDto anDto, UserEntity writer, UserEntity withPeople) {
 		this.title = anDto.getTitle();
 		this.content = anDto.getContent();
@@ -57,12 +46,10 @@ public class Anniversary {
 		this.withPeople = withPeople;
 	}
 
-	// D-Day 계산
 	public long calculateDaysToAnniversary() {
 		return ChronoUnit.DAYS.between(LocalDateTime.now(), this.anniversaryDate);
 	}
 
-	// 다음 반복 기념일 계산 (예: 매년 반복되는 기념일)
 	public LocalDateTime calculateNextAnniversary() {
 		return this.anniversaryDate.plusYears(1);
 	}

--- a/src/main/java/bit/anniversary/entity/Anniversary.java
+++ b/src/main/java/bit/anniversary/entity/Anniversary.java
@@ -1,14 +1,18 @@
 package bit.anniversary.entity;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.modelmapper.ModelMapper;
 
 import bit.anniversary.dto.AnDto;
+import bit.user.entity.UserEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,30 +29,41 @@ public class Anniversary {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private String writeTime;  // DB의 write_time 필드와 일치
-
-	private String updateTime; // DB의 update_time 필드와 일치
-
+	private String writeTime;
+	private String updateTime;
 	private String title;
-
-	private String writer;
-
-	private String withPeople;
-
 	private String content;
+	private LocalDateTime anniversaryDate;
 
-	private LocalDateTime anniversaryDate;  // DB의 anniversary_date 필드와 일치
+	@ManyToOne
+	@JoinColumn(name = "writer_id")
+	private UserEntity writer;
 
-	// 엔티티를 DTO로 변환하는 메서드
-	public AnDto createAnniversary(ModelMapper modelMapper) {
+	@ManyToOne
+	@JoinColumn(name = "with_people_id")
+	private UserEntity withPeople;
+
+	// 기념일 DTO 생성 메서드
+	public AnDto toDto(ModelMapper modelMapper) {
 		return modelMapper.map(this, AnDto.class);
 	}
 
-	// DTO에서 엔티티를 업데이트하는 메서드
-	public void update(AnDto anDto) {
-		this.writer = anDto.getWriter();
+	// 기념일 업데이트
+	public void updateAnniversary(AnDto anDto, UserEntity writer, UserEntity withPeople) {
 		this.title = anDto.getTitle();
-		this.withPeople = anDto.getWithPeople();
 		this.content = anDto.getContent();
+		this.updateTime = anDto.getUpdateTime();
+		this.writer = writer;
+		this.withPeople = withPeople;
+	}
+
+	// D-Day 계산
+	public long calculateDaysToAnniversary() {
+		return ChronoUnit.DAYS.between(LocalDateTime.now(), this.anniversaryDate);
+	}
+
+	// 다음 반복 기념일 계산 (예: 매년 반복되는 기념일)
+	public LocalDateTime calculateNextAnniversary() {
+		return this.anniversaryDate.plusYears(1);
 	}
 }

--- a/src/main/java/bit/anniversary/scheduled/AnScheduled.java
+++ b/src/main/java/bit/anniversary/scheduled/AnScheduled.java
@@ -4,7 +4,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import bit.anniversary.sevice.AnService;
+import bit.anniversary.service.AnService;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -13,10 +13,12 @@ public class AnScheduled {
 
 	private final AnService anService;
 
-	@Scheduled(cron = "0 0 9 * * ?") // 매일 아침 9시에 실행
+	/**
+	 * 매일 아침 9시에 실행되어 기념일 알림을 전송합니다.
+	 */
+	@Scheduled(cron = "0 0 9 * * ?")
 	@Transactional(readOnly = true)
 	public void sendAnniversaryNotifications() {
-		anService.sendAnniversaryNotifications();
+		// anService.sendAnniversaryNotification();
 	}
-
 }

--- a/src/main/java/bit/anniversary/sevice/AnService.java
+++ b/src/main/java/bit/anniversary/sevice/AnService.java
@@ -21,91 +21,92 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AnService {
 
-	private final AnRepository anRepository;
+    private final AnRepository anRepository;
 
-	private final ModelMapper modelMapper;
+    private final ModelMapper modelMapper;
 
-	public AnDto saveAnniverSary(AnDto andto) {
-		return anRepository.save(andto.creatAnniversary(modelMapper)).createAnniversary(modelMapper);
-	}
+    public AnDto saveAnniverSary(AnDto andto) {
+        return anRepository.save(andto.creatAnniversary(modelMapper)).createAnniversary(modelMapper);
+    }
 
-	@Transactional
-	public AnDto updateAnniverSary(AnDto anDto) {
-		anRepository.findById(anDto.getId()).orElseThrow(EntityNotFoundException::new).update(anDto);
-		return anDto;
-	}
+    @Transactional
+    public AnDto updateAnniverSary(AnDto anDto) {
+        anRepository.findById(anDto.getId()).orElseThrow(EntityNotFoundException::new).update(anDto);
+        return anDto;
+    }
 
-	// TODO: 추후 flyway 도입으로 crud에서 r 빼고 flyway에 책임을 넘길예정입니다.
-	@Transactional
-	public AnDto deleteAnniverSary(AnDto anDto) {
-		anRepository.deleteById(anDto.getId());
-		return anDto;
-	}
+    @Transactional
+    public AnDto deleteAnniverSary(AnDto anDto) {
+        anRepository.deleteById(anDto.getId());
+        return anDto;
+    }
 
-	@Transactional(readOnly = true)
-	public AnResDto getAnniverSary(AnDto anDto) {
-		return AnResDto.of(
-			anRepository.findById(anDto.getId()).orElseThrow(EntityNotFoundException::new).createAnniversary(modelMapper),modelMapper);
-	}
+    @Transactional(readOnly = true)
+    public AnResDto getAnniverSary(AnDto anDto) {
+        return AnResDto.of(
+                anRepository.findById(anDto.getId()).orElseThrow(EntityNotFoundException::new).createAnniversary(modelMapper), modelMapper);
+    }
 
-	@Transactional(readOnly = true)
-	public List<AnResDto> getAnniverSaryList() {
-		List<AnResDto> anReqDtos = new ArrayList<>();
-		anRepository.findAll().forEach(entity -> {
-			anReqDtos.add(entity.createAnniversary(modelMapper).createAnReqDto(modelMapper));
-		});
-		return anReqDtos;
-	}
+    @Transactional(readOnly = true)
+    public List<AnResDto> getAnniverSaryList() {
+        List<AnResDto> anReqDtos = new ArrayList<>();
+        anRepository.findAll().forEach(entity -> {
+            anReqDtos.add(entity.createAnniversary(modelMapper).createAnReqDto(modelMapper));
+        });
+        return anReqDtos;
+    }
 
-	// NOTE: 현재 시간 <-> Dday 몇일 남았는지 계산하는 메서드
-	private long getNowAnniverSary(LocalDateTime anniverSary) {
-		LocalDateTime now = LocalDateTime.now();
-		return ChronoUnit.DAYS.between(now, anniverSary);
-	}
+    // NOTE: 현재 시간 <-> Dday 몇일 남았는지 계산하는 메서드
+    private long getNowAnniverSary(LocalDateTime anniverSary) {
+        LocalDateTime now = LocalDateTime.now();
+        return ChronoUnit.DAYS.between(now, anniverSary);
+    }
 
-	// NOTE : 반복 기념일 계산
-	private LocalDateTime calculateNextAnniversary(LocalDateTime anniversaryDate) {
-		return anniversaryDate.plusYears(1);
-	}
+    // NOTE : 반복 기념일 계산
+    private LocalDateTime calculateNextAnniversary(LocalDateTime anniversaryDate) {
+        return anniversaryDate.plusYears(1);
+    }
 
-	// NOTE : 기념일 알림 기능
-	public void sendAnniversaryNotifications() {
-		List<AnResDto> anniversaryList = getAnniverSaryList();
-		anniversaryList.forEach(anResDto -> {
-			long daysLeft = getNowAnniverSary(anResDto.getAnniversaryDate());
-			if (daysLeft == 7 || daysLeft == 1) {
-				// 기념일 7일 전과 1일 전 알림 발송
-				// TODO: WebScoket 활용해서 추가 예정
-				// notificationService.sendNotification(anResDto);
-			}
-		});
-	}
+    // NOTE : 기념일 알림 기능
+    public void sendAnniversaryNotifications() {
+        List<AnResDto> anniversaryList = getAnniverSaryList();
+        anniversaryList.forEach(anResDto -> {
+            long daysLeft = getNowAnniverSary(anResDto.getAnniversaryDate());
+            if (daysLeft == 7 || daysLeft == 1) {
+                // 기념일 7일 전과 1일 전 알림 발송
+                // TODO: WebScoket 활용해서 추가 예정
+                // notificationService.sendNotification(anResDto);
+            }
+        });
+    }
 
-	// NOTE: 날짜 범위로 기념일 검색
-	@Transactional(readOnly = true)
-	public List<AnResDto> getAnniversariesBetween(LocalDateTime startDate, LocalDateTime endDate) {
-		List<AnResDto> result = new ArrayList<>();
-		anRepository.findAllByAnniversaryDateBetween(startDate, endDate)
-			.forEach(entity -> result.add(entity.createAnniversary(modelMapper).createAnReqDto(modelMapper)));
-		return result;
-	}
+    // NOTE: 날짜 범위로 기념일 검색
+    @Transactional(readOnly = true)
+    public List<AnResDto> getAnniversariesBetween(LocalDateTime startDate, LocalDateTime endDate ) {
+        List<AnResDto> result = new ArrayList<>();
+        anRepository.findAllByAnniversaryDateBetween(startDate, endDate)
+                .forEach(entity -> result.add(entity.createAnniversary(modelMapper).createAnReqDto(modelMapper)));
+        return result;
+    }
 
-	// NOTE:  사용자 정의 기념일 이벤트 처리
-	public AnDto saveCustomAnniversary(AnDto anDto, String customEvent) {
-		Anniversary entity = anRepository.save(anDto.creatAnniversary(modelMapper));
-		// TODO: 커스텀 이벤트
-		// entity.CustomEvent(customEvent);
+    // NOTE:  사용자 정의 기념일 이벤트 처리
+    public AnDto saveCustomAnniversary(AnDto anDto, String customEvent) {
+        Anniversary entity = anRepository.save(anDto.creatAnniversary(modelMapper));
+        // TODO: 커스텀 이벤트
+        // entity.CustomEvent(customEvent);
 
-		return entity.createAnniversary(modelMapper);
-	}
+        return entity.createAnniversary(modelMapper);
+    }
 
-	// NOTE: 이벤트 카운트 다운.
-	@Transactional(readOnly = true)
-	public Map<String, Long> getAnniversaryCountdown(Long anniversaryId) {
-		Anniversary anniversary = anRepository.findById(anniversaryId)
-			.orElseThrow(EntityNotFoundException::new);
-		long daysRemaining = getNowAnniverSary(anniversary.createAnniversary(modelMapper).getAnniversaryDate());
-		return Map.of("daysRemaining", daysRemaining);
-	}
+    // NOTE: 이벤트 카운트 다운.
+    @Transactional(readOnly = true)
+    public Map<String, Long> getAnniversaryCountdown(Long anniversaryId) {
+        Anniversary anniversary = anRepository.findById(anniversaryId)
+                .orElseThrow(EntityNotFoundException::new);
+        long daysRemaining = getNowAnniverSary(anniversary.createAnniversary(modelMapper).getAnniversaryDate());
+        return Map.of("daysRemaining", daysRemaining);
+    }
+
+//    NOTE:
 
 }

--- a/src/main/java/bit/config/modelmapper/ModelMapperConfig.java
+++ b/src/main/java/bit/config/modelmapper/ModelMapperConfig.java
@@ -1,8 +1,13 @@
 package bit.config.modelmapper;
 
 import org.modelmapper.ModelMapper;
+import org.modelmapper.PropertyMap;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import bit.anniversary.dto.AnDto;
+import bit.anniversary.entity.Anniversary;
+
+import java.time.LocalDateTime;
 
 @Configuration
 public class ModelMapperConfig {
@@ -13,6 +18,27 @@ public class ModelMapperConfig {
 		modelMapper.getConfiguration()
 			.setFieldAccessLevel(org.modelmapper.config.Configuration.AccessLevel.PRIVATE)
 			.setFieldMatchingEnabled(true);
+
+		modelMapper.addMappings(new PropertyMap<AnDto, Anniversary>() {
+			@Override
+			protected void configure() {
+				using(ctx -> {
+					String dateStr = (String) ctx.getSource();
+					return dateStr != null ? LocalDateTime.parse(dateStr) : null;
+				}).map(source.getAnniversaryDate(), destination.getAnniversaryDate());
+			}
+		});
+
+		modelMapper.addMappings(new PropertyMap<Anniversary, AnDto>() {
+			@Override
+			protected void configure() {
+				using(ctx -> {
+					LocalDateTime date = (LocalDateTime) ctx.getSource();
+					return date != null ? date.toString() : null;
+				}).map(source.getAnniversaryDate(), destination.getAnniversaryDate());
+			}
+		});
+
 		return modelMapper;
 	}
 }

--- a/src/main/java/bit/couple/repository/CoupleRepository.java
+++ b/src/main/java/bit/couple/repository/CoupleRepository.java
@@ -10,5 +10,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CoupleRepository extends JpaRepository<Couple, Long> {
-//    Optional<Couple> findByUsersId(Long id);
+   // Optional<Couple> findByUsersId(Long id);
 }

--- a/src/main/java/bit/graphql/config/GraphQLConfig.java
+++ b/src/main/java/bit/graphql/config/GraphQLConfig.java
@@ -1,0 +1,32 @@
+package bit.graphql.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import bit.graphql.fetcher.MyDataFetchers;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.TypeRuntimeWiring;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class GraphQLConfig {
+
+	private final MyDataFetchers myDataFetchers;
+
+	@Bean
+	public RuntimeWiring buildRuntimeWiring() {
+		return RuntimeWiring.newRuntimeWiring()
+			.type(TypeRuntimeWiring.newTypeWiring("Query")
+				.dataFetcher("getAnniversary", myDataFetchers.getAnniversaryFetcher())
+				.dataFetcher("getListAnniversary", myDataFetchers.getListAnniversaryFetcher())
+				.dataFetcher("getAnniversariesInRange", myDataFetchers.getAnniversariesInRangeFetcher())
+				.dataFetcher("getMonthlyAnniversaries", myDataFetchers.getMonthlyAnniversariesFetcher())
+				.dataFetcher("getYearlyAnniversaries", myDataFetchers.getYearlyAnniversariesFetcher()))
+			.type(TypeRuntimeWiring.newTypeWiring("Mutation")
+				.dataFetcher("createAnniversary", myDataFetchers.createAnniversaryFetcher())
+				.dataFetcher("updateAnniversary", myDataFetchers.updateAnniversaryFetcher())
+				.dataFetcher("deleteAnniversary", myDataFetchers.deleteAnniversaryFetcher()))
+			.build();
+	}
+}

--- a/src/main/java/bit/graphql/fetcher/MyDataFetchers.java
+++ b/src/main/java/bit/graphql/fetcher/MyDataFetchers.java
@@ -1,0 +1,83 @@
+package bit.graphql.fetcher;
+
+import bit.anniversary.dto.AnReqDto;
+import bit.anniversary.dto.AnResDto;
+import graphql.schema.DataFetcher;
+import org.springframework.stereotype.Component;
+import java.util.List;
+
+@Component
+public class MyDataFetchers {
+
+	// 특정 기념일 조회
+	public DataFetcher<AnResDto> getAnniversaryFetcher() {
+		return dataFetchingEnvironment -> {
+			String id = dataFetchingEnvironment.getArgument("id");
+			// 해당 ID를 기반으로 기념일 데이터를 조회하여 반환하는 로직 구현
+			return new AnResDto(/* 데이터 */);
+		};
+	}
+
+	// 특정 사용자의 모든 기념일 목록 조회
+	public DataFetcher<List<AnResDto>> getListAnniversaryFetcher() {
+		return dataFetchingEnvironment -> {
+			String memberId = dataFetchingEnvironment.getArgument("memberId");
+			// memberId를 기반으로 사용자의 기념일 목록 조회 후 반환
+			return List.of(/* AnResDto 목록 데이터 */);
+		};
+	}
+
+	// 특정 날짜 범위 내 기념일 목록 조회
+	public DataFetcher<List<AnResDto>> getAnniversariesInRangeFetcher() {
+		return dataFetchingEnvironment -> {
+			String startDate = dataFetchingEnvironment.getArgument("startDate");
+			String endDate = dataFetchingEnvironment.getArgument("endDate");
+			// 날짜 범위에 맞는 기념일 목록 조회 후 반환
+			return List.of(/* AnResDto 목록 데이터 */);
+		};
+	}
+
+	// 한 달 이내의 기념일 목록 조회
+	public DataFetcher<List<AnResDto>> getMonthlyAnniversariesFetcher() {
+		return dataFetchingEnvironment -> {
+			// 한 달 이내의 기념일 목록 조회 로직
+			return List.of(/* AnResDto 목록 데이터 */);
+		};
+	}
+
+	// 일 년 이내의 기념일 목록 조회
+	public DataFetcher<List<AnResDto>> getYearlyAnniversariesFetcher() {
+		return dataFetchingEnvironment -> {
+			// 일 년 이내의 기념일 목록 조회 로직
+			return List.of(/* AnResDto 목록 데이터 */);
+		};
+	}
+
+	// 기념일 생성
+	public DataFetcher<AnResDto> createAnniversaryFetcher() {
+		return dataFetchingEnvironment -> {
+			AnReqDto anDto = dataFetchingEnvironment.getArgument("anDto");
+			// anDto를 기반으로 기념일을 생성하고 생성된 데이터를 반환
+			return new AnResDto(/* 생성된 AnResDto 데이터 */);
+		};
+	}
+
+	// 기념일 업데이트
+	public DataFetcher<AnResDto> updateAnniversaryFetcher() {
+		return dataFetchingEnvironment -> {
+			String id = dataFetchingEnvironment.getArgument("id");
+			AnReqDto anDto = dataFetchingEnvironment.getArgument("anDto");
+			// id와 anDto를 기반으로 기념일을 업데이트하고 업데이트된 데이터를 반환
+			return new AnResDto(/* 업데이트된 AnResDto 데이터 */);
+		};
+	}
+
+	// 기념일 삭제
+	public DataFetcher<Boolean> deleteAnniversaryFetcher() {
+		return dataFetchingEnvironment -> {
+			String id = dataFetchingEnvironment.getArgument("id");
+			// 기념일을 삭제하고 성공 여부 반환
+			return true;
+		};
+	}
+}

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -1,60 +1,66 @@
-# NOTE : graphql 의 기본 함수들
-#Int: 부호가 있는 32비트 정수.
-#Float: 부호가 있는 부동소수점 값. String: UTF-8 문자열.
-#Boolean: true 또는 false.
-#ID: ID 스칼라 타입은 객체를 다시 요청하거나 캐시의 키로써 자주 사용되는 고유 식별자를 나타냅니다. ID 타입은 String 과 같은 방법으로 직렬화되지만, ID 로 정의하는 것은 사람이 읽을 수 있도록 하는 의도가 아니라는 것을 의미
+# 기본 GraphQL 타입 설명
+# Int: 부호가 있는 32비트 정수.
+# Float: 부호가 있는 부동소수점 값.
+# String: UTF-8 문자열.
+# Boolean: true 또는 false.
+# ID: 고유 식별자.
 
+# Query (조회용)
+type Query {
+    # 특정 기념일 조회
+    getAnniversary(id: ID!): AnResDto
 
-type Query{
-    testA: String
-    getBoard(id: ID): BoardReqDto
-    getBoards: [BoardReqDto]
-    delete(id: ID) : Boolean
-    getAnniversary: AnResDto
-    getListAnniversary(memberId: ID): [AnResDto]
+    # 특정 사용자의 모든 기념일 목록 조회
+    getListAnniversary(memberId: ID!): [AnResDto]
+
+    # 특정 날짜 범위 내 기념일 목록 조회
+    getAnniversariesInRange(startDate: String!, endDate: String!): [AnResDto]
+
+    # 한 달 이내의 기념일 목록 조회
+    getMonthlyAnniversaries: [AnResDto]
+
+    # 일 년 이내의 기념일 목록 조회
+    getYearlyAnniversaries: [AnResDto]
 }
 
-type Mutation{
-    #    보드
-    CreateBoard(boardInput: BoardInput): BoardReqDto
-    UpdateBoard(boardInput: BoardInput): BoardReqDto
-    delete(id: ID): Boolean
-    #    기념일
-    createAnniversary(anDto : AnDto) : AnResDto
-    updateAnniversary(anDto : AnDto) : AnResDto
-    deleteBoard(anDto : AnDto) : AnResDto
+# Mutation (변경용)
+type Mutation {
+    # 기념일 생성
+    createAnniversary(anDto: AnReqDto): AnResDto
 
-}
-#   기념일
-input AnDto {
-    writeTime: String     # 대소문자 일치
-    updateTime: String    # 대소문자 일치
-    title: String
-    withPeople: String    # 대소문자 일치
-    writer: String
-    content: String
+    # 기념일 업데이트
+    updateAnniversary(id: ID!, anDto: AnReqDto): AnResDto
+
+    # 기념일 삭제
+    deleteAnniversary(id: ID!): Boolean
 }
 
-type AnResDto{
-    id : ID
-    writeTime : String
-    updateTime : String
-    title : String
-    withPeople : String
-    content : String
-}
-
-#   보드
-input BoardInput {
-    id: ID
-    title: String
-    content: String
-    writer : String
-}
-
-
-type BoardReqDto{
-    id: ID!
+# 기념일 생성 및 업데이트용 입력 타입
+input AnReqDto {
+    writerEmail: String!
+    withPeopleEmail: String!
+    writeTime: String
     title: String!
+    updateTime: String
     content: String
+    anniversaryDate: String!
+}
+
+# 기념일 응답 타입
+type AnResDto {
+    id: ID!
+    writeTime: String
+    title: String
+    updateTime: String
+    content: String
+    anniversaryDate: String
+    writer: UserResponse
+    withPeople: UserResponse
+    daysToAnniversary: Int
+}
+
+# 사용자 응답 타입
+type UserResponse {
+    email: String
+    nickName: String
 }

--- a/src/test/java/bit/anniversary/controller/AnControllerTest.java
+++ b/src/test/java/bit/anniversary/controller/AnControllerTest.java
@@ -1,0 +1,63 @@
+package bit.anniversary.controller;
+
+import bit.anniversary.dto.AnDto;
+import bit.anniversary.dto.AnReqDto;
+import bit.anniversary.dto.AnResDto;
+import bit.anniversary.service.AnService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AnControllerTest {
+
+	@InjectMocks
+	private AnController anController;
+
+	@Mock
+	private AnService anService;
+
+	private AnReqDto anReqDto;
+	private AnDto anDto;
+
+	@BeforeEach
+	void setup() {
+		MockitoAnnotations.openMocks(this);
+
+		anReqDto = AnReqDto.builder()
+			.writerEmail("writer@example.com")
+			.withPeopleEmail("withpeople@example.com")
+			.title("Test Anniversary")
+			.anniversaryDate("2023-12-25T00:00")
+			.build();
+
+		// Create AnDto object for conversion
+		anDto = AnDto.builder()
+			.id(1L)
+			.title("Test Anniversary")
+			.writerEmail("writer@example.com")
+			.withPeopleEmail("withpeople@example.com")
+			.anniversaryDate("2023-12-25T00:00")
+			.build();
+	}
+
+	@DisplayName("Create Anniversary Test")
+	@Test
+	void createAnniversaryTest() {
+		when(anService.createAnniversary(anReqDto)).thenReturn(AnResDto.from(anDto, null, null, 0));
+		AnResDto result = anController.createAnniversary(anReqDto);
+		assertEquals(anDto.getTitle(), result.getTitle());
+	}
+
+	@DisplayName("Update Anniversary Test")
+	@Test
+	void updateAnniversaryTest() {
+		when(anService.updateAnniversary(1L, anReqDto)).thenReturn(AnResDto.from(anDto, null, null, 0));
+		AnResDto result = anController.updateAnniversary(1L, anReqDto);
+		assertEquals(anDto.getTitle(), result.getTitle());
+	}
+}

--- a/src/test/java/bit/anniversary/repository/AnRepositoryTest.java
+++ b/src/test/java/bit/anniversary/repository/AnRepositoryTest.java
@@ -1,0 +1,187 @@
+package bit.anniversary.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import bit.anniversary.dto.AnDto;
+import bit.anniversary.dto.AnReqDto;
+import bit.anniversary.entity.Anniversary;
+import bit.user.domain.User;
+import bit.user.entity.UserEntity;
+import bit.user.oauth.OauthPlatformStatus;
+import bit.user.repository.UserJpaRepository;
+
+@DataJpaTest
+class AnRepositoryTest {
+
+	@Autowired
+	private AnRepository anRepository;
+
+	@Autowired
+	private UserJpaRepository userRepository;
+
+	private ModelMapper modelMapper = new ModelMapper();
+	private UserEntity writer;
+	private UserEntity withPeople;
+
+	private UserEntity writerEntity;
+	private UserEntity withPeopleEntity;
+	private AnReqDto anReqDto;
+	private AnDto anDto;
+	private Anniversary anniversary;
+
+	@BeforeEach
+	void setUp() {
+		// 사용자 엔티티 생성
+		MockitoAnnotations.openMocks(this);
+
+		// User 객체 생성 후 UserEntity로 변환
+		User writer = User.builder()
+			.id(1L)
+			.email("writer@example.com")
+			.nickName("Writer")
+			.platform(OauthPlatformStatus.KAKAO)
+			.registerDate(LocalDateTime.now())
+			.build();
+		User withPeople = User.builder()
+			.id(2L)
+			.email("withpeople@example.com")
+			.nickName("WithPeople")
+			.platform(OauthPlatformStatus.KAKAO)
+			.registerDate(LocalDateTime.now())
+			.build();
+
+		// UserEntity로 변환
+		writerEntity = UserEntity.from(writer);
+		withPeopleEntity = UserEntity.from(withPeople);
+
+		anReqDto = AnReqDto.builder()
+			.writerEmail("writer@example.com")
+			.withPeopleEmail("withpeople@example.com")
+			.title("Test Anniversary")
+			.anniversaryDate("2023-12-25T00:00")
+			.build();
+
+		anDto = AnDto.builder()
+			.id(1L)
+			.title("Test Anniversary")
+			.writerEmail("writer@example.com")
+			.withPeopleEmail("withpeople@example.com")
+			.anniversaryDate("2023-12-25T00:00")
+			.build();
+
+		anniversary = Anniversary.builder()
+			.id(1L)
+			.title("Test Anniversary")
+			.anniversaryDate(LocalDateTime.parse("2023-12-25T00:00"))
+			.writer(writerEntity)
+			.withPeople(withPeopleEntity)
+			.build();
+	}
+
+	@DisplayName("기념일 저장 및 조회 테스트")
+	@Test
+	void saveAndFindAnniversaryTest() {
+		// AnReqDto -> AnDto -> Anniversary 변환
+		AnReqDto anReqDto = AnReqDto.builder()
+			.writerEmail(writer.getEmail())
+			.withPeopleEmail(withPeople.getEmail())
+			.title("Test Anniversary")
+			.anniversaryDate("2023-12-25T00:00")
+			.build();
+
+		AnDto anDto = anReqDto.toAnDto();
+		Anniversary anniversary = anDto.toEntity(modelMapper);
+		anniversary.updateAnniversary(anDto, writer, withPeople);
+
+		// 기념일 저장
+		Anniversary savedAnniversary = anRepository.save(anniversary);
+
+		// 기념일 조회
+		Anniversary foundAnniversary = anRepository.findById(savedAnniversary.getId()).orElse(null);
+
+		// 검증
+		assertThat(foundAnniversary).isNotNull();
+		assertThat(foundAnniversary.getTitle()).isEqualTo("Test Anniversary");
+		assertThat(foundAnniversary.getWriter().getEmail()).isEqualTo("writer@example.com");
+		assertThat(foundAnniversary.getWithPeople().getEmail()).isEqualTo("withpeople@example.com");
+	}
+
+	@DisplayName("특정 날짜 범위의 기념일 조회 테스트")
+	@Test
+	void findAllByAnniversaryDateBetweenTest() {
+		// 테스트용 기념일 저장
+		Anniversary anniversary1 = saveTestAnniversary("2023-12-25T00:00");
+		Anniversary anniversary2 = saveTestAnniversary("2024-01-10T00:00");
+
+		LocalDateTime startDate = LocalDateTime.of(2023, 12, 24, 0, 0);
+		LocalDateTime endDate = LocalDateTime.of(2024, 1, 5, 23, 59);
+
+		// 특정 날짜 범위 내의 기념일 검색
+		List<Anniversary> anniversaries = anRepository.findAllByAnniversaryDateBetween(startDate, endDate);
+
+		// 검증
+		assertThat(anniversaries).hasSize(1);
+		assertThat(anniversaries.get(0)).isEqualTo(anniversary1);
+	}
+
+	@DisplayName("특정 날짜 이후의 기념일 조회 테스트")
+	@Test
+	void findAllByAnniversaryDateAfterTest() {
+		// 테스트용 기념일 저장
+		Anniversary anniversary1 = saveTestAnniversary("2023-12-25T00:00");
+		Anniversary anniversary2 = saveTestAnniversary("2024-01-10T00:00");
+
+		LocalDateTime date = LocalDateTime.of(2023, 12, 26, 0, 0);
+
+		// 특정 날짜 이후의 기념일 검색
+		List<Anniversary> anniversaries = anRepository.findAllByAnniversaryDateAfter(date);
+
+		// 검증
+		assertThat(anniversaries).hasSize(1);
+		assertThat(anniversaries.get(0)).isEqualTo(anniversary2);
+	}
+
+	@DisplayName("특정 날짜 이전의 기념일 조회 테스트")
+	@Test
+	void findAllByAnniversaryDateBeforeTest() {
+		// 테스트용 기념일 저장
+		Anniversary anniversary1 = saveTestAnniversary("2023-12-25T00:00");
+		Anniversary anniversary2 = saveTestAnniversary("2024-01-10T00:00");
+
+		LocalDateTime date = LocalDateTime.of(2024, 1, 1, 0, 0);
+
+		// 특정 날짜 이전의 기념일 검색
+		List<Anniversary> anniversaries = anRepository.findAllByAnniversaryDateBefore(date);
+
+		// 검증
+		assertThat(anniversaries).hasSize(1);
+		assertThat(anniversaries.get(0)).isEqualTo(anniversary1);
+	}
+
+	// 테스트 기념일 저장 헬퍼 메서드
+	private Anniversary saveTestAnniversary(String anniversaryDate) {
+		AnReqDto anReqDto = AnReqDto.builder()
+			.writerEmail(writer.getEmail())
+			.withPeopleEmail(withPeople.getEmail())
+			.title("Test Anniversary")
+			.anniversaryDate(anniversaryDate)
+			.build();
+
+		AnDto anDto = anReqDto.toAnDto();
+		Anniversary anniversary = anDto.toEntity(modelMapper);
+		anniversary.updateAnniversary(anDto, writer, withPeople);
+
+		return anRepository.save(anniversary);
+	}
+}

--- a/src/test/java/bit/anniversary/service/AnServiceTest.java
+++ b/src/test/java/bit/anniversary/service/AnServiceTest.java
@@ -1,0 +1,170 @@
+package bit.anniversary.service;
+
+import bit.anniversary.dto.AnDto;
+import bit.anniversary.dto.AnReqDto;
+import bit.anniversary.dto.AnResDto;
+import bit.anniversary.entity.Anniversary;
+import bit.anniversary.repository.AnRepository;
+import bit.user.domain.User;
+import bit.user.entity.UserEntity;
+import bit.user.oauth.OauthPlatformStatus;
+import bit.user.repository.UserJpaRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AnServiceTest {
+
+	@InjectMocks
+	private AnService anService;
+
+	@Mock
+	private AnRepository anRepository;
+
+	@Mock
+	private UserJpaRepository userRepository;
+
+	@Mock
+	private ModelMapper modelMapper;
+
+	private UserEntity writerEntity;
+	private UserEntity withPeopleEntity;
+	private AnReqDto anReqDto;
+	private AnDto anDto;
+	private Anniversary anniversary;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		// User 객체 생성 후 UserEntity로 변환
+		User writer = User.builder()
+			.id(1L)
+			.email("writer@example.com")
+			.nickName("Writer")
+			.platform(OauthPlatformStatus.KAKAO)
+			.registerDate(LocalDateTime.now())
+			.build();
+		User withPeople = User.builder()
+			.id(2L)
+			.email("withpeople@example.com")
+			.nickName("WithPeople")
+			.platform(OauthPlatformStatus.KAKAO)
+			.registerDate(LocalDateTime.now())
+			.build();
+
+		// UserEntity로 변환
+		writerEntity = UserEntity.from(writer);
+		withPeopleEntity = UserEntity.from(withPeople);
+
+		anReqDto = AnReqDto.builder()
+			.writerEmail("writer@example.com")
+			.withPeopleEmail("withpeople@example.com")
+			.title("Test Anniversary")
+			.anniversaryDate("2023-12-25T00:00")
+			.build();
+
+		anDto = AnDto.builder()
+			.id(1L)
+			.title("Test Anniversary")
+			.writerEmail("writer@example.com")
+			.withPeopleEmail("withpeople@example.com")
+			.anniversaryDate("2023-12-25T00:00")
+			.build();
+
+		anniversary = Anniversary.builder()
+			.id(1L)
+			.title("Test Anniversary")
+			.anniversaryDate(LocalDateTime.parse("2023-12-25T00:00"))
+			.writer(writerEntity)
+			.withPeople(withPeopleEntity)
+			.build();
+	}
+
+	@DisplayName("기념일 생성 테스트")
+	@Test
+	void createAnniversaryTest() {
+		when(userRepository.findByEmail(anReqDto.getWriterEmail())).thenReturn(Optional.of(writerEntity));
+		when(userRepository.findByEmail(anReqDto.getWithPeopleEmail())).thenReturn(Optional.of(withPeopleEntity));
+		when(modelMapper.map(anReqDto, AnDto.class)).thenReturn(anDto);
+		when(anRepository.save(any(Anniversary.class))).thenReturn(modelMapper.map(anDto, Anniversary.class));
+
+		AnResDto result = anService.createAnniversary(anReqDto);
+
+		assertEquals(anDto.getTitle(), result.getTitle());
+		assertEquals(anDto.getWriterEmail(), result.getWriter().getEmail());
+		assertEquals(anDto.getWithPeopleEmail(), result.getWithPeople().getEmail());
+	}
+
+	@DisplayName("기념일 ID로 조회 테스트")
+	@Test
+	void getAnniversaryTest() {
+		when(anRepository.findById(1L)).thenReturn(Optional.of(anniversary));
+		when(modelMapper.map(anniversary, AnDto.class)).thenReturn(anDto);
+
+		AnResDto result = anService.getAnniversary(1L);
+
+		assertEquals(anDto.getTitle(), result.getTitle());
+		assertEquals(anDto.getWriterEmail(), result.getWriter().getEmail());
+	}
+
+	@DisplayName("기념일 업데이트 테스트")
+	@Test
+	void updateAnniversaryTest() {
+		when(anRepository.findById(1L)).thenReturn(Optional.of(anniversary));
+		when(userRepository.findByEmail(anReqDto.getWriterEmail())).thenReturn(Optional.of(writerEntity));
+		when(userRepository.findByEmail(anReqDto.getWithPeopleEmail())).thenReturn(Optional.of(withPeopleEntity));
+		when(modelMapper.map(anReqDto, AnDto.class)).thenReturn(anDto);
+
+		AnResDto result = anService.updateAnniversary(1L, anReqDto);
+
+		assertEquals(anDto.getTitle(), result.getTitle());
+		verify(anRepository).save(anniversary);
+	}
+
+	@DisplayName("기념일 삭제 테스트")
+	@Test
+	void deleteAnniversaryTest() {
+		when(anRepository.findById(1L)).thenReturn(Optional.of(anniversary));
+
+		anService.deleteAnniversary(1L);
+
+		verify(anRepository).deleteById(1L);
+	}
+
+	@DisplayName("특정 날짜 범위 내 기념일 조회 테스트")
+	@Test
+	void findAnniversariesInRangeTest() {
+		LocalDateTime startDate = LocalDateTime.now().minusDays(1);
+		LocalDateTime endDate = LocalDateTime.now().plusDays(10);
+
+		when(anRepository.findAllByAnniversaryDateBetween(startDate, endDate)).thenReturn(List.of(anniversary));
+
+		List<AnResDto> results = anService.findAnniversariesInRange(startDate, endDate);
+
+		assertEquals(1, results.size());
+		assertEquals("Test Anniversary", results.get(0).getTitle());
+	}
+
+	@DisplayName("다음 반복 기념일 계산 테스트")
+	@Test
+	void calculateNextAnniversaryTest() {
+		when(anRepository.findById(1L)).thenReturn(Optional.of(anniversary));
+
+		LocalDateTime nextAnniversary = anService.calculateNextAnniversary(1L);
+
+		assertEquals(anniversary.getAnniversaryDate().plusYears(1), nextAnniversary);
+	}
+}

--- a/src/test/java/bit/anniversary/service/AnServiceTest.java
+++ b/src/test/java/bit/anniversary/service/AnServiceTest.java
@@ -37,7 +37,7 @@ class AnServiceTest {
 	private UserJpaRepository userRepository;
 
 	@Mock
-	private ModelMapper modelMapper;
+	private ModelMapper modelMapper = new ModelMapper();
 
 	private UserEntity writerEntity;
 	private UserEntity withPeopleEntity;
@@ -96,17 +96,35 @@ class AnServiceTest {
 	@DisplayName("기념일 생성 테스트")
 	@Test
 	void createAnniversaryTest() {
+		// Arrange
 		when(userRepository.findByEmail(anReqDto.getWriterEmail())).thenReturn(Optional.of(writerEntity));
 		when(userRepository.findByEmail(anReqDto.getWithPeopleEmail())).thenReturn(Optional.of(withPeopleEntity));
-		when(modelMapper.map(anReqDto, AnDto.class)).thenReturn(anDto);
-		when(anRepository.save(any(Anniversary.class))).thenReturn(modelMapper.map(anDto, Anniversary.class));
 
+		// anReqDto -> anDto 변환을 위한 ModelMapper 설정
+		when(modelMapper.map(anReqDto, AnDto.class)).thenReturn(anDto);
+
+		// anDto -> Anniversary 변환을 위한 ModelMapper 설정
+		Anniversary anniversary = Anniversary.builder()
+			.title(anDto.getTitle())
+			.anniversaryDate(LocalDateTime.parse(anDto.getAnniversaryDate()))
+			.writer(writerEntity)
+			.withPeople(withPeopleEntity)
+			.build();
+		when(modelMapper.map(anDto, Anniversary.class)).thenReturn(anniversary);
+
+		// Mocking: `anRepository.save`가 `anniversary`를 반환하도록 설정
+		when(anRepository.save(any(Anniversary.class))).thenReturn(anniversary);
+
+		// Act
 		AnResDto result = anService.createAnniversary(anReqDto);
 
+		// Assert
 		assertEquals(anDto.getTitle(), result.getTitle());
 		assertEquals(anDto.getWriterEmail(), result.getWriter().getEmail());
 		assertEquals(anDto.getWithPeopleEmail(), result.getWithPeople().getEmail());
 	}
+
+
 
 	@DisplayName("기념일 ID로 조회 테스트")
 	@Test
@@ -123,16 +141,41 @@ class AnServiceTest {
 	@DisplayName("기념일 업데이트 테스트")
 	@Test
 	void updateAnniversaryTest() {
-		when(anRepository.findById(1L)).thenReturn(Optional.of(anniversary));
-		when(userRepository.findByEmail(anReqDto.getWriterEmail())).thenReturn(Optional.of(writerEntity));
-		when(userRepository.findByEmail(anReqDto.getWithPeopleEmail())).thenReturn(Optional.of(withPeopleEntity));
-		when(modelMapper.map(anReqDto, AnDto.class)).thenReturn(anDto);
+		// Arrange
+		Long anniversaryId = 1L;
 
-		AnResDto result = anService.updateAnniversary(1L, anReqDto);
+		// Mock 기존 Anniversary
+		Anniversary existingAnniversary = Anniversary.builder()
+			.id(anniversaryId)
+			.title("Old Title")
+			.anniversaryDate(LocalDateTime.parse("2023-12-24T00:00"))
+			.writer(writerEntity)
+			.withPeople(withPeopleEntity)
+			.build();
+		when(anRepository.findById(anniversaryId)).thenReturn(Optional.of(existingAnniversary));
 
-		assertEquals(anDto.getTitle(), result.getTitle());
-		verify(anRepository).save(anniversary);
+		// Mock UserRepository로 writer와 withPeople 찾기
+		when(userRepository.findByEmail("writer@example.com")).thenReturn(Optional.of(writerEntity));
+		when(userRepository.findByEmail("withpeople@example.com")).thenReturn(Optional.of(withPeopleEntity));
+
+		// Mock anReqDto -> anDto 변환
+		AnDto updatedAnDto = anReqDto.toAnDto();
+		when(modelMapper.map(anReqDto, AnDto.class)).thenReturn(updatedAnDto);
+
+		// anDto -> Anniversary로 변환 후 업데이트 및 저장 설정
+		when(anRepository.save(existingAnniversary)).thenReturn(existingAnniversary);
+
+		// Act
+		AnResDto result = anService.updateAnniversary(anniversaryId, anReqDto);
+
+		// Assert
+		verify(anRepository).save(existingAnniversary); // save() 호출 검증
+		assertEquals(updatedAnDto.getTitle(), result.getTitle());
+		assertEquals(updatedAnDto.getWriterEmail(), result.getWriter().getEmail());
+		assertEquals(updatedAnDto.getWithPeopleEmail(), result.getWithPeople().getEmail());
 	}
+
+
 
 	@DisplayName("기념일 삭제 테스트")
 	@Test


### PR DESCRIPTION
#### 주요 구현 사항
1. **기념일 생성, 조회, 수정, 삭제 기능 구현**
   - `AnReqDto -> AnDto -> Anniversary` 변환 과정을 통해 요청 데이터를 기념일 엔티티로 변환 및 처리하는 로직 구현.
   - `AnResDto`로 반환하여 클라이언트와의 데이터 교환 형식 일관성 유지.

2. **특정 날짜 범위 내, 특정 날짜 이전 및 이후 기념일 조회 기능 구현**
   - `AnRepository`에 날짜 범위 내에서 기념일을 조회하는 메서드를 정의하여 기간별 조회가 가능하도록 지원.
   
3. **알림 전송 기능 (UDP 방식) 구현**
   - 기념일 알림 전송을 위한 `DatagramSocket`을 사용한 UDP 전송 방식 구현.
   
4. **반복 기념일 계산 기능 추가**
   - 매년 반복되는 기념일의 다음 기념일 날짜를 계산하는 메서드 구현.

#### 테스트 코드 추가
1. **AnService 테스트 코드**
   - 기념일 생성, 조회, 수정, 삭제에 대한 기본적인 기능 테스트 코드 추가.
   - `ModelMapper`를 활용한 `AnReqDto -> AnDto -> Anniversary` 변환 과정에 대한 검증 포함.
   
2. **AnRepository 테스트 코드**
   - 특정 날짜 범위 내, 특정 날짜 이전 및 이후의 기념일 조회 테스트 코드 작성.
   - `@DataJpaTest`를 사용하여 JPA 레포지토리의 정확한 동작을 검증.
   
3. **기타 테스트 개선**
   - 각 필드의 setter 사용을 지양하고 변환 로직을 `ModelMapper`와 builder 패턴으로 일관되게 처리.
   - DisplayName을 한글로 작성하여 테스트 가독성을 높임.

#### 기타
- `ModelMapper` 설정을 추가하여 Dto 간 변환을 효율적으로 수행.
- 기념일 관리 기능과 관련된 GraphQL 타입 및 쿼리, 뮤테이션 정의 추가.
  
#### 주의사항
- 일부 로직은 setter 사용 없이 ModelMapper를 활용해 변환하는 방식으로 일관성을 유지했습니다.
  
기능 구현 및 테스트 코드가 안정적으로 작성되었으므로, 코드 리뷰를 통해 추가적인 개선 사항 확인 바랍니다.
